### PR TITLE
Handle hue values below 0 and above 359 degrees properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,6 +115,10 @@ Color.prototype = {
       return this.setChannel("rgb", 2, val);
    },
    hue: function(val) {
+      if (val) {
+        val = val % 360;
+        val = val < 0 ? 360 + val : val;
+      }
       return this.setChannel("hsl", 0, val);
    },
    saturation: function(val) {

--- a/test/index.js
+++ b/test/index.js
@@ -93,6 +93,10 @@ it('Channel getters/setters', function() {
   equal(Color({h: 10, s: 20, l: 30}).hue(100).hue(), 100);
   equal(Color({h: 10, w: 20, b: 30}).hue(), 10);
   equal(Color({h: 10, w: 20, b: 30}).hue(100).hue(), 100);
+  equal(Color({h: 10, s: 20, l: 30}).hue(), 10);
+  equal(Color({h: 10, s: 20, l: 30}).hue(460).hue(), 100);
+  equal(Color({h: 10, w: 20, b: 30}).hue(), 10);
+  equal(Color({h: 10, w: 20, b: 30}).hue(-260).hue(), 100);
 });
 
 it('Setting the same value', function () {


### PR DESCRIPTION
Moved from ianstormtaylor/css-color-function#16:
> According to [W3C CSS color draft](https://drafts.csswg.org/css-color/#typedef-hue) one can specify values both below 0 and above 359 degrees.
> > The angle `0deg` represents red (as does `360deg`, `720deg`, etc.)